### PR TITLE
Save/Restore wrap setting

### DIFF
--- a/plugin/golden_ratio.vim
+++ b/plugin/golden_ratio.vim
@@ -119,9 +119,12 @@ function! s:toggle_global_golden_ratio()
     let s:gr_auto = 0
     au! GoldenRatioAug
 
-    let currbuf = bufnr("%")
-    bufdo if match(keys(s:lwrap), bufname('%')) >= 0
-          \ | exe 'setl '.s:lwrap[bufname("%")]
+    let currbuf = bufnr('%')
+    bufdo let bufname = bufname('%')
+          \ | if !empty(bufname)
+            \ | if match(keys(s:lwrap), bufname) >= 0
+              \ | exe 'setl '.s:lwrap[bufname]
+            \ | endif
           \ | endif
     exe 'buffer ' . currbuf
 


### PR DESCRIPTION
Hi Roman,

This is a small addition to save and restore the local wrap setting when toggling golden-ratio. It can also be extended to save/restore the original windows layout by including the lines and columns values, but that's up to you.
