### PR TITLE
Fix for ignoring 'set nowrap' in users' '.vimrc'.

### DIFF
--- a/plugin/golden_ratio.vim
+++ b/plugin/golden_ratio.vim
@@ -33,8 +33,6 @@ function! s:find_parallel_windows(current_window)
 endfunction
 
 function! s:resize_ignored_window(windows, ignored_width, ignored_height)
-  setl nowrap
-
   if len(a:windows.width) > 0 && index(a:windows.width, winnr()) >= 0
     let l:width_size = a:ignored_width / len(a:windows.width)
     exec printf("vertical resize %f", l:width_size)
@@ -67,7 +65,6 @@ endfunction
 function! s:resize_main_window(window,
       \ main_width, main_height,
       \ ignored_width, ignored_height)
-  setl wrap
 
   " Height has an special condition:
   " When there is only one window, or just windows


### PR DESCRIPTION
I found that Golden Ratio ignored my preferred setting for `nowrap` in my `.vimrc`.

I can't see a reason for wrapping to be changed when resizing 'main' and 'ignored' windows, so I've removed these lines. I've since used Vim with both 'wrap' and 'nowrap' set and the functionality doesn't appear to have changed.
