### PR TITLE
Add option to ignore all nonmodifiable windows.

### DIFF
--- a/doc/golden_ratio.txt
+++ b/doc/golden_ratio.txt
@@ -49,6 +49,15 @@ Use this option to set line wrapping of the ignored windows
   let g:golden_ratio_wrap_ignored = 0
 <
 
+                                         *'golden_ratio_exclude_nonmodifiable'*
+Use this option to keep all windows that have 'nomodifiable' option set
+untouched (off by default): >
+  let g:golden_ratio_exclude_nonmodifiable = 1
+<
+This is useful if you keep things like buffer explorer or tag list
+open. Note: Depending on the window layout this may not always work.
+
+
 ===============================================================================
 3. Commands                                             *golden-ratio-commands*
 

--- a/plugin/golden_ratio.vim
+++ b/plugin/golden_ratio.vim
@@ -17,6 +17,10 @@ if !exists('g:golden_ratio_wrap_ignored')
   let g:golden_ratio_wrap_ignored = 0
 endif
 
+if !exists('g:golden_ratio_exclude_nonmodifiable')
+  let g:golden_ratio_exclude_nonmodifiable = 0
+endif
+
 function! s:golden_ratio_width()
   return &columns / 1.618
 endfunction
@@ -25,12 +29,20 @@ function! s:golden_ratio_height()
   return &lines / 1.618
 endfunction
 
+function! s:window_list()
+  let wl = range(1, winnr('$'))
+  if g:golden_ratio_exclude_nonmodifiable
+    let wl = filter(wl, 'getwinvar(v:val, "&modifiable")')
+  endif
+  return wl
+endfunction
+
 function! s:find_parallel_windows(current_window)
   return {
-         \ 'width' : filter(reverse(range(1, winnr('$'))),
+         \ 'width' : filter(reverse(s:window_list()),
            \ 'winheight(v:val) == winheight(a:current_window) ' .
            \ '&& v:val != a:current_window'),
-         \ 'height': filter(reverse(range(1, winnr('$'))),
+         \ 'height': filter(reverse(s:window_list()),
            \ 'winwidth(v:val) == winwidth(a:current_window) ' .
            \ '&& v:val != a:current_window')
         \}
@@ -100,6 +112,10 @@ endfunction
 function! s:resize_to_golden_ratio()
   if exists("b:golden_ratio_resizing_ignored") &&
         \ b:golden_ratio_resizing_ignored
+    return
+  endif
+
+  if g:golden_ratio_exclude_nonmodifiable && !&modifiable
     return
   endif
 


### PR DESCRIPTION
This is useful for buffer explorers or tag lists since they usualy have
they own way of handling the size of the window.
