### PR TITLE
Add an option to blacklist some filetypes

### DIFF
--- a/doc/golden_ratio.txt
+++ b/doc/golden_ratio.txt
@@ -57,6 +57,11 @@ untouched (off by default): >
 This is useful if you keep things like buffer explorer or tag list
 open. Note: Depending on the window layout this may not always work.
 
+                                         *'golden_ratio_filetypes_blacklist'*
+Use this option to keep all windows that have 'nomodifiable' option set
+untouched (off by default): >
+  let g:golden_ratio_filetypes_blacklist = ["nerdtree", "unite"]
+<
 
 ===============================================================================
 3. Commands                                             *golden-ratio-commands*

--- a/plugin/golden_ratio.vim
+++ b/plugin/golden_ratio.vim
@@ -21,6 +21,10 @@ if !exists('g:golden_ratio_exclude_nonmodifiable')
   let g:golden_ratio_exclude_nonmodifiable = 0
 endif
 
+if !exists("g:golden_ratio_filetypes_blacklist")
+  let g:golden_ratio_filetypes_blacklist = []
+endif
+
 function! s:golden_ratio_width()
   return &columns / 1.618
 endfunction
@@ -146,12 +150,8 @@ function! s:initiate_golden_ratio()
     aug GoldenRatioAug
       au!
 
-      if !exists("g:golden_ratio_filetypes_blacklist")
-        let g:golden_ratio_filetypes_blacklist = []
-      endif
-
       au WinEnter,BufEnter * if index(g:golden_ratio_filetypes_blacklist, &ft) < 0 | call <SID>resize_to_golden_ratio() | endif
-      au BufLeave * let b:golden_ratio_saved_wrap = &wrap
+      au BufLeave * if index(g:golden_ratio_filetypes_blacklist, &ft) < 0 | let b:golden_ratio_saved_wrap = &wrap | endif
     aug END
   endif
 endfunction

--- a/plugin/golden_ratio.vim
+++ b/plugin/golden_ratio.vim
@@ -145,7 +145,12 @@ function! s:initiate_golden_ratio()
   if s:gr_auto
     aug GoldenRatioAug
       au!
-      au WinEnter,BufEnter * call <SID>resize_to_golden_ratio()
+
+      if !exists("g:golden_ratio_filetypes_blacklist")
+        let g:golden_ratio_filetypes_blacklist = []
+      endif
+
+      au WinEnter,BufEnter * if index(g:golden_ratio_filetypes_blacklist, &ft) < 0 | call <SID>resize_to_golden_ratio() | endif
       au BufLeave * let b:golden_ratio_saved_wrap = &wrap
     aug END
   endif


### PR DESCRIPTION
This will prevent special buffers from getting resized (i.e.: NERDTree, Unite, etc.)

Fixes #3
