### PR TITLE
Don't allow resizing from cmdwin

### DIFF
--- a/plugin/golden_ratio.vim
+++ b/plugin/golden_ratio.vim
@@ -123,6 +123,12 @@ function! s:resize_to_golden_ratio()
     return
   endif
 
+  " Prevent "E11: Invalid in command-line window". We cannot leave cmdwin to
+  " resize windows, so abort.
+  if exists('*getcmdwintype') && !empty(getcmdwintype())
+    return
+  endif
+
   let l:ah = s:golden_ratio_height()
   let l:bh = l:ah / 1.618
 


### PR DESCRIPTION
Fix #36.

The cmdwin does not allow you to leave and if you try you get E11.
Forbid it so users don't get pointless errors.

getcmdwintype was added in 2014, but this plugin is older than that, so
be careful.