### PR TITLE
Add check for existence of new function before calling it to fix usage of golden ratio in older versions of vim/nvim

### DIFF
--- a/plugin/golden_ratio.vim
+++ b/plugin/golden_ratio.vim
@@ -115,7 +115,7 @@ endfunction
 
 function! s:resize_to_golden_ratio()
 
-  if win_gettype(winnr()) == 'popup'
+  if exists('*win_gettype') && win_gettype(winnr()) == 'popup'
     return
   endif
 


### PR DESCRIPTION
Addresses #41 

An early return was added to golden ratio to skip resizing if the window type was a "popup".

The function used is a new nvim feature so it doesn't exist in older versions of nvim or vim (what I happen to be using).

This PR checks for existence of the new function before calling it for users who happen to not be able to update their versions of vim/nvim.

Alternatives: If this PR isn't accepted, I suppose an acceptable solution on my side would be to pin the version of golden ratio I'm using and not get any more updates.

**Testing**
1. launch an older version of vim (ex `8.0.707`)
2. Install the plugin
3. On load of vim/nvim, you should not see any errors emitted in the console.